### PR TITLE
chore(common): jenkinsfile CD 파이프라인 추가 (#14)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,17 +45,19 @@ pipeline {
 
         stage('Docker Build & Push') {
             steps {
-                sh "echo ${DOCKER_HUB_PSW} | docker login -u ${DOCKER_HUB_USR} --password-stdin"
+                script {
+                    sh "echo ${DOCKER_HUB_PSW} | docker login -u ${DOCKER_HUB_USR} --password-stdin"
 
-                // dev 브랜치일 때 버전 태그(dev-숫자)를 같이 생성
-                sh "docker build -t ${DOCKER_USERNAME}/voteland-backend:latest ."
-                sh "docker tag ${DOCKER_USERNAME}/voteland-backend:latest ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}"
-                sh "docker push ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}"
+                    // dev 브랜치일 때만 dev-숫자 태그로 빌드 및 푸시
+                    if (env.BRANCH_NAME == 'dev') {
+                        sh "docker build -t ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER} ."
+                        sh "docker push ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}"
 
-                dir('frontend') {
-                    sh "docker build -t ${DOCKER_USERNAME}/voteland-frontend:latest ."
-                    sh "docker tag ${DOCKER_USERNAME}/voteland-frontend:latest ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}"
-                    sh "docker push ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}"
+                        dir('frontend') {
+                            sh "docker build -t ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER} ."
+                            sh "docker push ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}"
+                        }
+                    }
                 }
             }
             post {
@@ -64,7 +66,6 @@ pipeline {
                 }
             }
         }
-    }
 
         stage('Update K8s Manifest') {
             when {
@@ -72,28 +73,36 @@ pipeline {
             }
             steps {
                 script {
-                    sh "git config --global user.email 'jenkins@voteland.com'"
-                    sh "git config --global user.name 'Jenkins Bot'"
-
                     withCredentials([usernamePassword(credentialsId: 'github-token-id', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PWD')]) {
+                        sh 'rm -rf k8s-repo || true'
                         sh "git clone https://${GIT_USER}:${GIT_PWD}@github.com/coffiiness/voteland-k8s-repo.git k8s-repo"
                     }
 
                     dir('k8s-repo') {
+                        sh "git config user.email 'jenkins@voteland.com'"
+                        sh "git config user.name 'Jenkins Bot'"
+
                         sh "git checkout dev"
 
-                        // (:dev 태그를 :dev-빌드번호 로 변경)
                         sh "sed -i 's|image: .*/voteland-backend:.*|image: ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}|g' k8s/backend/deployment.yaml"
+
                         sh "sed -i 's|image: .*/voteland-frontend:.*|image: ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}|g' k8s/frontend/deployment.yaml"
 
-                        sh "git add ."
-                        sh "git commit -m 'Update image tag to dev-${env.BUILD_NUMBER}'"
-                        sh "git push origin dev"
+                        // 변경사항 커밋 & 푸시
+                        sh '''
+                            if [ -n "$(git status --porcelain)" ]; then
+                                git add .
+                                git commit -m "Update image tag to dev-${BUILD_NUMBER}"
+                                git push origin dev
+                            else
+                                echo "No changes to commit"
+                            fi
+                        '''
                     }
                 }
             }
         }
-
+    }
     post {
         success {
             node('') {
@@ -106,7 +115,7 @@ pipeline {
                                 "fields": [
                                     {"name": "Job", "value": "''' + env.JOB_NAME + '''", "inline": true},
                                     {"name": "Branch", "value": "''' + env.BRANCH_NAME + '''", "inline": true},
-                                    {"name": "Build", "value": "#''' + env.BUILD_NUMBER + '''", "inline": true}
+                                    {"name": "Image Tag", "value": "dev-''' + env.BUILD_NUMBER + '''", "inline": true}
                                 ]
                             }]
                         }' "$DISCORD_WEBHOOK"
@@ -125,7 +134,7 @@ pipeline {
                                 "fields": [
                                     {"name": "Job", "value": "''' + env.JOB_NAME + '''", "inline": true},
                                     {"name": "Branch", "value": "''' + env.BRANCH_NAME + '''", "inline": true},
-                                    {"name": "링크", "value": "[로그 확인](''' + env.BUILD_URL + ''')"}
+                                    {"name": "Link", "value": "[로그 확인](''' + env.BUILD_URL + ''')"}
                                 ]
                             }]
                         }' "$DISCORD_WEBHOOK"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,32 +67,32 @@ pipeline {
     }
 
         stage('Update K8s Manifest') {
-                    when {
-                        branch 'dev'
+            when {
+                branch 'dev'
+            }
+            steps {
+                script {
+                    sh "git config --global user.email 'jenkins@voteland.com'"
+                    sh "git config --global user.name 'Jenkins Bot'"
+
+                    withCredentials([usernamePassword(credentialsId: 'github-token-id', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PWD')]) {
+                        sh "git clone https://${GIT_USER}:${GIT_PWD}@github.com/coffiiness/voteland-k8s-repo.git k8s-repo"
                     }
-                    steps {
-                        script {
-                            sh "git config --global user.email 'jenkins@voteland.com'"
-                            sh "git config --global user.name 'Jenkins Bot'"
 
-                            withCredentials([usernamePassword(credentialsId: 'github-token-id', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PWD')]) {
-                                sh "git clone https://${GIT_USER}:${GIT_PWD}@github.com/coffiiness/voteland-k8s-repo.git k8s-repo"
-                            }
+                    dir('k8s-repo') {
+                        sh "git checkout dev"
 
-                            dir('k8s-repo') {
-                                sh "git checkout dev"
+                        // (:dev 태그를 :dev-빌드번호 로 변경)
+                        sh "sed -i 's|image: .*/voteland-backend:.*|image: ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}|g' k8s/backend/deployment.yaml"
+                        sh "sed -i 's|image: .*/voteland-frontend:.*|image: ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}|g' k8s/frontend/deployment.yaml"
 
-                                // (:dev 태그를 :dev-빌드번호 로 변경)
-                                sh "sed -i 's|image: .*/voteland-backend:.*|image: ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}|g' k8s/backend/deployment.yaml"
-                                sh "sed -i 's|image: .*/voteland-frontend:.*|image: ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}|g' k8s/frontend/deployment.yaml"
-
-                                sh "git add ."
-                                sh "git commit -m 'Update image tag to dev-${env.BUILD_NUMBER}'"
-                                sh "git push origin dev"
-                            }
-                        }
+                        sh "git add ."
+                        sh "git commit -m 'Update image tag to dev-${env.BUILD_NUMBER}'"
+                        sh "git push origin dev"
                     }
                 }
+            }
+        }
 
     post {
         success {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,8 +72,8 @@ pipeline {
                     }
                     steps {
                         script {
-                            sh "git config --global user.email 'jenkins@voteland.com'"
-                            sh "git config --global user.name 'Jenkins Bot'"
+                            sh "git config user.email 'jenkins@voteland.com'"
+                            sh "git config user.name 'Jenkins Bot'"
 
                             withCredentials([usernamePassword(credentialsId: 'github-token-id', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PWD')]) {
                                 sh "git clone https://${GIT_USER}:${GIT_PWD}@github.com/coffiiness/voteland-k8s-repo.git k8s-repo"
@@ -87,7 +87,7 @@ pipeline {
                                 sh "sed -i 's|image: .*/voteland-frontend:.*|image: ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}|g' k8s/frontend/deployment.yaml"
 
                                 sh "git add ."
-                                sh "git commit -m 'Update image tag to dev-${env.BUILD_NUMBER}'"
+                                sh "git diff --staged --quiet || git commit -m 'Update image tag to dev-${env.BUILD_NUMBER}'"
                                 sh "git push origin dev"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,12 +47,15 @@ pipeline {
             steps {
                 sh "echo ${DOCKER_HUB_PSW} | docker login -u ${DOCKER_HUB_USR} --password-stdin"
 
+                // dev 브랜치일 때 버전 태그(dev-숫자)를 같이 생성
                 sh "docker build -t ${DOCKER_USERNAME}/voteland-backend:latest ."
-                sh "docker push ${DOCKER_USERNAME}/voteland-backend:latest"
+                sh "docker tag ${DOCKER_USERNAME}/voteland-backend:latest ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}"
+                sh "docker push ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}"
 
                 dir('frontend') {
                     sh "docker build -t ${DOCKER_USERNAME}/voteland-frontend:latest ."
-                    sh "docker push ${DOCKER_USERNAME}/voteland-frontend:latest"
+                    sh "docker tag ${DOCKER_USERNAME}/voteland-frontend:latest ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}"
+                    sh "docker push ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}"
                 }
             }
             post {
@@ -63,6 +66,34 @@ pipeline {
         }
     }
 
+        stage('Update K8s Manifest') {
+                    when {
+                        branch 'dev'
+                    }
+                    steps {
+                        script {
+                            sh "git config --global user.email 'jenkins@voteland.com'"
+                            sh "git config --global user.name 'Jenkins Bot'"
+
+                            withCredentials([usernamePassword(credentialsId: 'github-token-id', usernameVariable: 'GIT_USER', passwordVariable: 'GIT_PWD')]) {
+                                sh "git clone https://${GIT_USER}:${GIT_PWD}@github.com/coffiiness/voteland-k8s-repo.git k8s-repo"
+                            }
+
+                            dir('k8s-repo') {
+                                sh "git checkout dev"
+
+                                // (:dev 태그를 :dev-빌드번호 로 변경)
+                                sh "sed -i 's|image: .*/voteland-backend:.*|image: ${DOCKER_USERNAME}/voteland-backend:dev-${env.BUILD_NUMBER}|g' k8s/backend/deployment.yaml"
+                                sh "sed -i 's|image: .*/voteland-frontend:.*|image: ${DOCKER_USERNAME}/voteland-frontend:dev-${env.BUILD_NUMBER}|g' k8s/frontend/deployment.yaml"
+
+                                sh "git add ."
+                                sh "git commit -m 'Update image tag to dev-${env.BUILD_NUMBER}'"
+                                sh "git push origin dev"
+                            }
+                        }
+                    }
+                }
+
     post {
         success {
             node('') {
@@ -70,7 +101,7 @@ pipeline {
                     sh '''
                         curl -X POST -H "Content-Type: application/json" -d '{
                             "embeds": [{
-                                "title": "빌드 성공 ✅",
+                                "title": "빌드 & 배포 업데이트 성공 ✅",
                                 "color": 3066993,
                                 "fields": [
                                     {"name": "Job", "value": "''' + env.JOB_NAME + '''", "inline": true},


### PR DESCRIPTION
## 💡 개요
> Dev 브랜치에 코드가 병합되면 자동으로 K8s 환경에 배포되도록 CD 파이프라인을 구축

## 🔗 관련 이슈
Closes #11 

## 📝 작업 상세 내용
- [ ] dev 브랜치 빌드 시, 배포 추적을 위해 latest 태그 외에 고유한 dev-${BUILD_NUMBER} 태그를 추가로 생성 및 푸시하도록 수정
- [ ] 빌드 후 K8s 설정 레포지토리(voteland-k8s-repo)를 클론하여 deployment.yaml을 수정하는 자동화 스크립트 구현
- [ ] sed 명령어로 백엔드/프론트엔드 이미지 태그를 교체하고, 이를 dev 브랜치에 자동 커밋/푸시하여 ArgoCD가 배포를 시작하도록 연동

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발 브랜치에서 Kubernetes 매니페스트를 자동으로 업데이트하도록 추가되었습니다.

* **개선 사항**
  * 개발 빌드에 빌드 번호 기반의 dev-태그가 적용되어 이미지 버전 추적이 쉬워졌습니다.
  * 배포 성공 알림 제목이 "빌드 & 배포 업데이트 성공 ✅"로 변경되었습니다.
  * 알림 내 항목명이 보다 명확하게 업데이트(예: "Build"→"Image Tag", 실패 시 "링크"→"Link")되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->