### PR TITLE
test(BE): 투표참여 API 문서화 메소드 작성 및 restdoc index 수정 (#39)

### DIFF
--- a/core/core-api/src/docs/asciidoc/index.adoc
+++ b/core/core-api/src/docs/asciidoc/index.adoc
@@ -1,15 +1,15 @@
-= API Docs
+= API Documentation
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
 :toc: left
-:toclevels: 3
+:toclevels: 2
 :sectlinks:
-:snippets: build/generated-snippets
+:sectnums:
+:docinfo: shared-head
 
-== Introduce
-
-This is the Core API documentation.
+== 개요 (Introduction)
+이 문서는 Core API 명세서입니다.
 
 == Users API
 
@@ -68,4 +68,16 @@ include::{snippets}/votes/request-fields.adoc[]
 include::{snippets}/votes/http-response.adoc[]
 ==== Response Fields
 include::{snippets}/votes/response-fields.adoc[]
+
+=== 투표 참여
+==== Curl Request
+include::{snippets}/vote-submit/curl-request.adoc[]
+==== Path Parameters
+include::{snippets}/vote-submit/path-parameters.adoc[]
+==== Request Fields
+include::{snippets}/vote-submit/request-fields.adoc[]
+==== Http Response
+include::{snippets}/vote-submit/http-response.adoc[]
+==== Response Fields
+include::{snippets}/vote-submit/response-fields.adoc[]
 

--- a/core/core-api/src/test/java/com/team/voteland/docs/votes/VoteApiDocs.java
+++ b/core/core-api/src/test/java/com/team/voteland/docs/votes/VoteApiDocs.java
@@ -4,6 +4,8 @@ import com.team.voteland.core.api.controller.v1.VoteController;
 import com.team.voteland.core.enums.VoteType;
 import com.team.voteland.docs.RestDocsTest;
 import com.team.voteland.domain.vote.api.v1.request.CreateVoteRequest;
+import com.team.voteland.domain.vote.api.v1.request.VoteSubmitRequest;
+import com.team.voteland.domain.vote.api.v1.response.VoteSubmitResponse;
 import com.team.voteland.domain.vote.domain.VoteService;
 import com.team.voteland.support.security.jwt.SecurityUser;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,11 +23,12 @@ import java.util.List;
 
 import static com.team.voteland.docs.RestDocsUtils.responsePreprocessor;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class VoteApiDocs extends RestDocsTest {
@@ -81,6 +84,31 @@ public class VoteApiDocs extends RestDocsTest {
                     fieldWithPath("options").description("투표 항목"), fieldWithPath("deadline").description("투표 마감 기간")),
                     responseFields(fieldWithPath("result").description("결과 타입 (SUCCESS/ERROR)"),
                             fieldWithPath("data").description("응답 데이터").optional(),
+                            fieldWithPath("error").description("에러 정보").optional())));
+    }
+
+    @Test
+    void 투표참여_API_문서화() throws Exception {
+        // given
+        VoteSubmitResponse response = new VoteSubmitResponse("투표가 완료되었습니다.", List.of(1L, 2L));
+
+        when(voteService.submitVote(anyLong(), anyLong(), any(VoteSubmitRequest.class))).thenReturn(response);
+        VoteSubmitRequest request = new VoteSubmitRequest(List.of(1L, 2L));
+
+        // when & then
+        mockMvc
+            .perform(post("/api/v1/votes/{voteId}/submit", 1L).contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)))
+            .andExpect(status().isOk())
+            .andDo(document("vote-submit", responsePreprocessor(),
+
+                    pathParameters(parameterWithName("voteId").description("참여할 투표의 ID")),
+
+                    requestFields(fieldWithPath("itemIds").description("선택한 투표 항목")),
+
+                    responseFields(fieldWithPath("result").description("결과 타입"),
+                            fieldWithPath("data.message").description("투표 완료 메시지"),
+                            fieldWithPath("data.votedItems").description("투표한 항목 ID 리스트"),
                             fieldWithPath("error").description("에러 정보").optional())));
     }
 


### PR DESCRIPTION
## 💡 개요
restdoc 문서 작성을 위한 테스트 코드 작성 및 가독성 향상을 위한 index 수정

## 🔗 관련 이슈
Closes #39

## 📝 작업 상세 내용
- [x] VoteApiDocs.java 클래스에 투표참여_API_문서화() 메소드 작성
- [x] index.adoc에 투표참여 내용 추가 및 템플릿 수정

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서화
* API 문서 구조 및 타이틀 개선
* 투표 참여 엔드포인트 문서화 추가 (경로 매개변수, 요청/응답 필드 포함)
* 한국어 콘텐츠 추가

## 테스트
* 투표 제출 API 문서화 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->